### PR TITLE
Lum 23665.new y2k birthday

### DIFF
--- a/fields/date_of_birth.json
+++ b/fields/date_of_birth.json
@@ -2,13 +2,7 @@
     "properties": {
         "date_of_birth": {
             "type": "date",
-            "format": "yyyy/MM/dd||epoch_millis",
-            "fields": {
-                "y2k_birthday": {
-                    "type": "date",
-                    "format": "yyyy/MM/dd||epoch_millis"
-                }
-            }
+            "format": "yyyy/MM/dd||epoch_millis"
         }
     }
 }

--- a/fields/y2k_birthday.json
+++ b/fields/y2k_birthday.json
@@ -1,0 +1,8 @@
+{
+    "properties": {
+        "y2k_birthday": {
+            "type": "date",
+            "format": "yyyy/MM/dd||epoch_millis"
+        }
+    }
+}


### PR DESCRIPTION
@blackbaud/team-cerebro y2k_birthday needs to be a new field on the constituent document, not a subfield of date_of_birth, since we need to populate it with different data (as opposed to just index the same data differently).